### PR TITLE
Added --preserve-metadata flag to preserve labels/annotations in secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ optional arguments:
   -v, --verbose         verbose output
   --trace               show the full stack trace when an SSLError happens
   -f, --force           replace a secret if it already exists
+  --preserve-metadata   preserve object's metadata while replacing secret
   -n NAMESPACE, --namespace NAMESPACE
                         kubernetes namespace
   -U, --uppercase       For lowercase keys in credstash, convert them


### PR DESCRIPTION
Issue: The labels & annotations were being erased from the secret as kubestash replaced the entire secret object.

Added --preserve-metadata optional flag, to preserve the existing metadata of the secret that is being replaced.
Tested by building a public image [khushdeep02/kubestash](https://hub.docker.com/r/khushdeep02/kubestash).